### PR TITLE
プロジェクト詳細のタブが狭い幅のときデザインが崩れるので修正

### DIFF
--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -26,7 +26,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        "bg-muted text-muted-foreground inline-flex h-auto w-fit items-center justify-center rounded-lg p-[3px] flex-wrap",
         className,
       )}
       {...props}


### PR DESCRIPTION
https://naokisyuu.atlassian.net/browse/DEVLINK-12